### PR TITLE
Potential fix for code scanning alert no. 2: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/nzpy/handshake.py
+++ b/nzpy/handshake.py
@@ -2,7 +2,7 @@ import base64
 import ssl
 from getpass import getuser
 from hashlib import md5
-from hashlib import sha256
+from argon2 import PasswordHasher
 from os import getpid, path
 from platform import system
 from socket import gethostname
@@ -561,10 +561,9 @@ class Handshake():
                     "authentication, but no password "
                     "was provided"
                     )
-            sha256encoded = sha256(salt+password)
-            sha256pwd = base64.standard_b64encode(sha256encoded.digest())
-            pwd = sha256pwd.rstrip(b"=")
-            self.log.debug("sha256 encrypted password is =%s", pwd)
+            ph = PasswordHasher()
+            pwd = ph.hash(salt + password)
+            self.log.debug("argon2 encrypted password is =%s", pwd)
 
             # Int32 - Message length including
             # String - The password.  Password may be encrypted.

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ pytest==8.3.5
 scramp==1.4.5
 tox==4.25.0
 virtualenv==20.31.2
+
+argon2-cffi==23.1.0


### PR DESCRIPTION
Potential fix for [https://github.com/Ayush900/nzpy/security/code-scanning/2](https://github.com/Ayush900/nzpy/security/code-scanning/2)

To address the issue, we will replace the use of SHA-256 with a more secure password hashing algorithm, such as Argon2, which is specifically designed for password hashing. Argon2 is computationally expensive, includes salting by default, and is resistant to brute-force attacks. 

The fix involves:
1. Importing the `argon2-cffi` library to use the `PasswordHasher` class.
2. Replacing the SHA-256 hashing logic with Argon2-based hashing.
3. Ensuring that the salt is incorporated into the Argon2 hashing process, as Argon2 automatically handles salting.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
